### PR TITLE
Fix for [BUG] New audiodevices aren't recognized while running. Resolves: #4

### DIFF
--- a/dgMicMute/App.xaml.cs
+++ b/dgMicMute/App.xaml.cs
@@ -33,7 +33,8 @@ namespace dgMicMute
             NotifyIconViewModel nivm = _notifyIcon.DataContext as NotifyIconViewModel;
 
             _bootstrapper = new Bootstrapper();
-            _bootstrapper.HotkeyPressed += nivm.HotkeyPressed;
+            _bootstrapper.Hook.KeyPressed += nivm.HotkeyPressed;
+            _bootstrapper.Hook.DevicesChanged += nivm.RefreshMicList;
 
             _bootstrapper.RegistrationException += (s, ex) =>
             {

--- a/dgMicMute/Bootstrapper.cs
+++ b/dgMicMute/Bootstrapper.cs
@@ -9,17 +9,14 @@ namespace dgMicMute
 {
     public class Bootstrapper
     {
-        public event EventHandler<KeyPressedEventArgs> HotkeyPressed;
         public event EventHandler<UnhandledExceptionEventArgs> RegistrationException;
 
-        KeyboardHook hook;
+        public KeyboardHook Hook = new KeyboardHook();
 
-        public void Init()
+		public void Init()
         {
             //Loads the settings
             SerializeStatic.Load(typeof(Settings));
-            hook = new KeyboardHook();
-            hook.KeyPressed += (s, e) => { if (HotkeyPressed != null) { HotkeyPressed.Invoke(s, e); } };
             RegisterHotkey();
             Settings.OnSettingsChanged += Settings_OnSettingsChanged;
         }
@@ -40,7 +37,7 @@ namespace dgMicMute
         {
             try
             {
-                hook.UnregisterHotkeys(); // unregister any hotkeys that might already have been registered
+                Hook.UnregisterHotkeys(); // unregister any hotkeys that might already have been registered
 
                 // Make sure "UsesHotKey" is true and we have, at minimum, a SelectedKey defined
                 if (Settings.UsesHotkey && !String.IsNullOrWhiteSpace(Settings.SelectedKey))
@@ -53,7 +50,7 @@ namespace dgMicMute
                     Keys selectedKey = Keys.None;
                     if (KeyMapper.AvailableKeys.TryGetValue(Settings.SelectedKey, out selectedKey))
                     {
-                        hook.RegisterHotKey(modifierKeys, selectedKey);
+                        Hook.RegisterHotKey(modifierKeys, selectedKey);
                     }
                     else
                     {
@@ -76,7 +73,7 @@ namespace dgMicMute
 
         public void Shutdown()
         {
-            hook.UnregisterHotkeys();
+            Hook.UnregisterHotkeys();
             SerializeStatic.Save(typeof(Settings));
         }
     }

--- a/dgMicMute/KeyboardHook.cs
+++ b/dgMicMute/KeyboardHook.cs
@@ -8,6 +8,10 @@ using System.Windows.Forms;
 
 namespace dgMicMute
 {
+    /// <summary>
+    /// Creates a window to receive and dispatch WM_HOTKEY messages.
+    /// Also now does the same for WM_DEVICECHANGE messages to detect when mics are added/removed, so it might make sense to rename the class.
+    /// </summary>
     public sealed class KeyboardHook : IDisposable
     {
         // Registers a hot key with Windows.
@@ -23,6 +27,7 @@ namespace dgMicMute
         private class Window : NativeWindow, IDisposable
         {
             private static int WM_HOTKEY = 0x0312;
+            private static int WM_DEVICECHANGE = 0x0219;
 
             public Window()
             {
@@ -49,9 +54,17 @@ namespace dgMicMute
                     if (KeyPressed != null)
                         KeyPressed(this, new KeyPressedEventArgs(modifier, key));
                 }
+                else if (m.Msg == WM_DEVICECHANGE)
+				{
+                    if (DevicesChanged != null)
+					{
+                        DevicesChanged(this, null);
+					}
+				}
             }
 
             public event EventHandler<KeyPressedEventArgs> KeyPressed;
+            public event EventHandler DevicesChanged;
 
             #region IDisposable Members
 
@@ -73,6 +86,11 @@ namespace dgMicMute
             {
                 if (KeyPressed != null)
                     KeyPressed(this, args);
+            };
+            _window.DevicesChanged += delegate (object sender, EventArgs args)
+            {
+                if (DevicesChanged != null)
+                    DevicesChanged(this, args);
             };
         }
 
@@ -101,6 +119,7 @@ namespace dgMicMute
         /// A hot key has been pressed.
         /// </summary>
         public event EventHandler<KeyPressedEventArgs> KeyPressed;
+        public event EventHandler DevicesChanged;
 
         #region IDisposable Members
 

--- a/dgMicMute/NotifyIconViewModel.cs
+++ b/dgMicMute/NotifyIconViewModel.cs
@@ -76,9 +76,17 @@ namespace dgMicMute
             ToggleMicrophoneCommand = new RelayCommand(ToggleMicrophone);
         }
 
+        public void RefreshMicList(object sender, EventArgs e)
+		{
+            _mic.Dispose();
+            _mic = new DgMic();
+            _mic.OnVolumeNotification += _mic_OnVolumeNotification;
+            IsMuted = Settings.IsMuted; // reassert the muted state on the new set of mics
+		}
+
         private void ToggleMicrophone(object obj)
         {
-            IsMuted = !IsMuted;
+            IsMuted = !Settings.IsMuted; // changed this to Settings.IsMuted instead of this.IsMuted to skip the unneeded side effect calls of that getter
         }
 
         public void HotkeyPressed(object sender, KeyPressedEventArgs e)


### PR DESCRIPTION
Hi, it's me again. :)  I ran into this same issue when I plugged in a new USB mic a few weeks ago, so when I saw you log this defect I thought I'd take a crack at fixing it.

I added another event for the WM_DEVICECHANGE message to KeyboardHook (so it's no longer concerned strictly with key messages, but I resisted the temptation to rename the class), so whenever a device is added/removed, the event gets dispatched to NotifyIconViewModel where it re-instantiates the DgMic instance to get a fresh view of what's there, then reasserts the mute status on the new list.

Speaking of event delegation, I noticed the hotkey event was taking an extra unnecessary hop through Bootstrapper, so I eliminated that by making the KeyboardHook accessible publicly (via Bootstrapper.Hook) and wiring the events directly to it in order to eliminate some extraneous code.  For that matter, the events are taking an extra hop internally (from _window to the KeyboardHook) which could be factored out to reduce the code a bit too.